### PR TITLE
Fix deprecated logging.warn usage in utils.py

### DIFF
--- a/DeepLense_Classification_Transformers_Archil_Srivastava/utils.py
+++ b/DeepLense_Classification_Transformers_Archil_Srivastava/utils.py
@@ -1,4 +1,4 @@
-from logging import warn
+import warnings
 import torch
 from torch.nn import Softmax
 import numpy as np
@@ -33,7 +33,7 @@ def get_device(device):
         return "mps"
     if device == "cpu" or device == "best":
         return "cpu"
-    warn(f"Requested device {device} not found, running on CPU")
+    warnings.warn(f"Requested device {device} not found, running on CPU")
     return "cpu"
 
 


### PR DESCRIPTION
This PR updates the deprecated logging.warn usage to warnings.warn in DeepLense_Classification_Transformers_Archil_Srivastava/utils.py.
The fix was applied successfully and validated by running tests in the updated file and cross-checking with another module.