### PR TITLE
Docs: add setup instructions for BYOL notebooks

### DIFF
--- a/Deeplens_Self_Supervised_Learning_Yashwardhan_Deshmukh/byol_learning/README.md
+++ b/Deeplens_Self_Supervised_Learning_Yashwardhan_Deshmukh/byol_learning/README.md
@@ -1,0 +1,17 @@
+# BYOL Self-Supervised Learning
+
+## Setup / Requirements
+
+The notebooks in this folder require the following Python dependencies:
+
+- imageio
+- numpy
+- pandas
+- torch
+- torchvision
+
+If `imageio` is not installed, the notebooks will fail in the first cell.
+
+Install the missing dependency with:
+```bash
+pip install imageio


### PR DESCRIPTION
This PR addresses issue #83.

The BYOL self-supervised learning notebooks currently fail on a fresh setup due to
a missing `imageio` dependency. This PR adds a minimal README in the `byol_learning`
folder documenting the required dependencies so new contributors can run the
notebooks without hitting an import error in the first cell.
