### PR TITLE
FIX: add missing imageio dependency to sub-project requirements

### DIFF
--- a/Domain_Adaptation_for_DeepLense_Marcos_Tidball/requirements.txt
+++ b/Domain_Adaptation_for_DeepLense_Marcos_Tidball/requirements.txt
@@ -6,3 +6,4 @@ matplotlib==3.4.3
 scikit-learn==0.24.2
 scipy==1.7.1
 seaborn==0.11.2
+imageio


### PR DESCRIPTION
This PR addresses Issue #83 by adding imageio to the requirements.txt files in the Domain_Adaptation and Transformers_Classification sub-projects. This prevents ModuleNotFoundError during environment setup.

Fixes #83.