### PR TITLE
Add requirements.txt for BYOL notebooks to fix missing imageio depend…

### DIFF
--- a/Deeplens_Self_Supervised_Learning_Yashwardhan_Deshmukh/requirements.txt
+++ b/Deeplens_Self_Supervised_Learning_Yashwardhan_Deshmukh/requirements.txt
@@ -1,0 +1,9 @@
+imageio
+numpy
+pandas
+tensorflow
+keras
+matplotlib
+tqdm
+pillow
+scikit-learn


### PR DESCRIPTION
This PR fixes Issue #83 by adding a requirements.txt file for the BYOL
(Self-Supervised Learning) notebooks.

Previously, running the notebooks on a fresh setup failed due to missing
dependencies such as `imageio`. This change improves reproducibility and
onboarding for new contributors.

Tested on a clean virtual environment.