### PR TITLE
Fix missing imageio dependency in mejiro-regression setup

### DIFF
--- a/DeepLense_Gravitational_Lens_Classification_Transformers_Dhruv_Srivastava/mejiro-regression/requirements.txt
+++ b/DeepLense_Gravitational_Lens_Classification_Transformers_Dhruv_Srivastava/mejiro-regression/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+scikit-learn
+imageio
+jupyter


### PR DESCRIPTION
This PR adds a requirements.txt file to the mejiro-regression subproject.

Issue:
On a fresh setup, the notebooks fail because the imageio dependency is missing.
This was a bit confusing at first, especially since the Jupyter notebook was
running in a different Python environment.

What I changed:
- Added a requirements.txt file with imageio included.
- This makes the setup clearer and helps new contributors run the notebooks
  without facing dependency-related errors.

Fixes #83
