### PR TITLE
Refactor hard-coded paths to config-driven lensid.yaml

### DIFF
--- a/DeepLense_Gravitational_Lens_Classification_Transformers_Dhruv_Srivastava/README.md
+++ b/DeepLense_Gravitational_Lens_Classification_Transformers_Dhruv_Srivastava/README.md
@@ -1,9 +1,11 @@
 # GSoC 2025 LensID
- Gravitational Lens Finding and Classification project under DeepLense
+
+Gravitational Lens Finding and Classification project under DeepLense
 
 Author: Dhruv Srivastava
 
 ## How to run the code
+
 IPython notebooks work out-of-the-box (tested on Google Colab). If generating the dataloaders for the first time, uncomment the lines such as: (in vision_transformer_basic.ipynb)
 
 ```
@@ -24,9 +26,76 @@ IPython notebooks work out-of-the-box (tested on Google Colab). If generating th
 #torch.save(train_loader, '/content/drive/MyDrive/Model_III_dataset/train_loader.pth')
 #torch.save(val_loader, '/content/drive/MyDrive/Model_III_dataset/val_loader.pth')
 ```
+
 Once dataloaders have been saved, simply load them through
+
 ```
 #import data loaders from file
 train_loader = torch.load('/content/drive/MyDrive/Model_III_dataset/train_loader.pth', weights_only=False)
 val_loader = torch.load('/content/drive/MyDrive/Model_III_dataset/val_loader.pth', weights_only=False)
 ```
+
+⚠️ **Note**
+
+- The hard-coded Google Drive paths are intended for Google Colab usage.
+- For local execution, update the dataset paths accordingly.
+- For local execution, users are encouraged to replace Colab paths with:
+
+```python
+train_dir = "./data/Model_III"
+```
+
+and save dataloaders locally:
+
+```
+torch.save(train_loader, "./data/train_loader.pth")
+```
+
+### Dataset Structure (Model III):
+
+The Vision Transformer models expect the dataset to be organized as follows:
+
+```
+data/
+└── Model_III/
+    ├── axion/
+    │   ├── *.npy
+    ├── cdm/
+    │   ├── *.npy
+    └── no_sub/
+        ├── *.npy
+```
+
+Each .npy file contains a 2D array representing a grayscale lensing image.
+The dataset is split into train/validation/test sets using
+torch.utils.data.random_split inside the notebook.
+
+### Local Setup (Non-Colab):
+
+The project can be run locally without Google Colab.
+
+Steps:
+
+1. Clone the repository.
+
+2. Create and activate a virtual environment.
+
+3. Install required dependencies.
+
+4. Place the dataset under data/Model_III/.
+
+5. Open and run the relevant notebook (e.g. vision_transformer_basic.ipynb).
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install torch torchvision numpy
+```
+
+### Notebook Execution Notes:
+
+- Dataset and DataLoader creation cells should be run once.
+
+- Saving DataLoaders using torch.save is optional and primarily intended for Colab usage.
+
+- Training, validation, and testing splits are performed programmatically.

--- a/DeepLense_Gravitational_Lens_Classification_Transformers_Dhruv_Srivastava/VisionTransformerBasic/vision_transformer_basic.ipynb
+++ b/DeepLense_Gravitational_Lens_Classification_Transformers_Dhruv_Srivastava/VisionTransformerBasic/vision_transformer_basic.ipynb
@@ -2,94 +2,87 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "source": [],
       "metadata": {
         "id": "X7Ekxmo1XV5I"
-      }
+      },
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import yaml\n",
+        "import shutil\n",
+        "from pathlib import Path"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "CONFIG_PATH = Path(\"../configs/lensid.yaml\")\n",
+        "\n",
+        "with open(CONFIG_PATH, \"r\") as f:\n",
+        "    cfg = yaml.safe_load(f)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
       "source": [
         "from google.colab import drive\n",
-        "drive.mount('/content/drive')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "_mFRKD8F__hl",
-        "outputId": "0495f67f-8d6b-4160-c594-cceaab989d2a"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Mounted at /content/drive\n"
-          ]
-        }
+        "drive.mount('/content/drive') #Google Drive mounting is required only when running in Colab."
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!cd /content/drive/MyDrive/Model_III_data/Model_III/axion\n",
-        "!ls -1q /content/drive/MyDrive/Model_III_data/Model_III/no_sub | wc -l"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "DMbel4LB8oLb",
-        "outputId": "7cc98f45-8719-4e02-c747-c15d4c1ff05c"
-      },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "30000\n"
-          ]
-        }
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "figures_dir = Path(cfg[\"outputs\"][\"figures_dir\"])\n",
+        "models_dir = Path(cfg[\"outputs\"][\"models_dir\"])\n",
+        "\n",
+        "figures_dir.mkdir(parents=True, exist_ok=True)\n",
+        "models_dir.mkdir(parents=True, exist_ok=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "- NOTE:\n",
+        "- Dataset artifacts (Model_III.tgz and preprocessed loaders)\n",
+        "- are not included in the repository.\n",
+        "- Users must place them manually at cfg[\"data\"][\"archive_path\"]."
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!ls /content/drive/MyDrive/Model_III_data/Model_III/"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9l0m91pCBpI1",
-        "outputId": "483f3706-70d6-4eaf-efaf-23bb1238f35a"
-      },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ls: cannot access '/content/drive/MyDrive/Model_III_data/Model_III/': No such file or directory\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#Extract tarfile\n",
-        "import shutil\n",
-        "shutil.unpack_archive('/content/drive/MyDrive/Model_III.tgz', '/content/drive/MyDrive/Model_III_dataset')"
-      ],
       "metadata": {
         "id": "_HwTHNYYAoBC"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "archive_path = Path(cfg[\"data\"][\"archive_path\"])\n",
+        "extract_dir = Path(cfg[\"data\"][\"extract_dir\"])\n",
+        "\n",
+        "if not archive_path.exists():\n",
+        "    raise FileNotFoundError(\n",
+        "        f\"Dataset archive not found at {archive_path}. \"\n",
+        "        \"Please place Model_III.tgz in the data/ directory.\"\n",
+        "    )\n",
+        "\n",
+        "if not extract_dir.exists():\n",
+        "    shutil.unpack_archive(archive_path, extract_dir)"
+      ]
     },
     {
       "cell_type": "code",
@@ -207,21 +200,13 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "VJEgowwT_txC",
-        "outputId": "de7672d2-1191-4930-adc3-37c424d0ad7c",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "VJEgowwT_txC",
+        "outputId": "de7672d2-1191-4930-adc3-37c424d0ad7c"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Training Directory: /content/drive/MyDrive/Model_III_dataset/Model_III\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Import the transforms module\n",
         "from torchvision import transforms\n",
@@ -231,7 +216,7 @@
         "num_epochs = 100\n",
         "\n",
         "# Data Directories\n",
-        "train_dir = '/content/drive/MyDrive/Model_III_dataset/Model_III'\n",
+        "train_dir = f'{cfg[\"data\"][\"dataset_root\"]}/train'\n",
         "#val_dir = '../dataset/dataset/val'\n",
         "\n",
         "print(f\"Training Directory: {train_dir}\")\n",
@@ -261,37 +246,45 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "#import data loaders from file\n",
-        "train_loader = torch.load('/content/drive/MyDrive/Model_III_dataset/train_loader.pth', weights_only=False)\n",
-        "val_loader = torch.load('/content/drive/MyDrive/Model_III_dataset/val_loader.pth', weights_only=False)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "gvqsjdgzKmOL"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "import torch\n",
+        "\n",
+        "dataset_root = Path(cfg[\"data\"][\"dataset_root\"])\n",
+        "\n",
+        "train_loader_path = dataset_root / \"train_loader.pth\"\n",
+        "val_loader_path = dataset_root / \"val_loader.pth\"\n",
+        "\n",
+        "if not train_loader_path.exists() or not val_loader_path.exists():\n",
+        "    raise FileNotFoundError(\n",
+        "        \"Preprocessed DataLoader files not found.\\n\"\n",
+        "        \"Expected:\\n\"\n",
+        "        f\"  - {train_loader_path}\\n\"\n",
+        "        f\"  - {val_loader_path}\\n\\n\"\n",
+        "        \"Please run the dataset preprocessing step first \"\n",
+        "        \"or obtain the preprocessed files.\"\n",
+        "    )\n",
+        "\n",
+        "train_loader = torch.load(train_loader_path, weights_only=False)\n",
+        "val_loader = torch.load(val_loader_path, weights_only=False)"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "y6Q9I1Hw_txD",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "y6Q9I1Hw_txD",
         "outputId": "3cbb9dc6-5dc1-4d81-cc79-3feb9bd3cf9f"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/timm/models/layers/__init__.py:48: FutureWarning: Importing from timm.models.layers is deprecated, please import via timm.layers\n",
-            "  warnings.warn(f\"Importing from {__name__} is deprecated, please import via timm.layers\", FutureWarning)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import torch\n",
         "import torch.nn as nn\n",
@@ -440,9 +433,7 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "#!pip install torch_xla[tpu]"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -450,48 +441,14 @@
         "id": "hivvAHcI41JJ",
         "outputId": "257c8cec-1eba-478e-ca04-286fede0f97c"
       },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting torch_xla[tpu]\n",
-            "  Downloading torch_xla-2.7.0-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (21 kB)\n",
-            "Requirement already satisfied: absl-py>=1.0.0 in /usr/local/lib/python3.11/dist-packages (from torch_xla[tpu]) (1.4.0)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.11/dist-packages (from torch_xla[tpu]) (2.0.2)\n",
-            "Requirement already satisfied: pyyaml in /usr/local/lib/python3.11/dist-packages (from torch_xla[tpu]) (6.0.2)\n",
-            "Requirement already satisfied: requests in /usr/local/lib/python3.11/dist-packages (from torch_xla[tpu]) (2.32.3)\n",
-            "Collecting libtpu==0.0.11.1 (from torch_xla[tpu])\n",
-            "  Downloading libtpu-0.0.11.1-py3-none-manylinux_2_31_x86_64.whl.metadata (556 bytes)\n",
-            "Collecting tpu-info (from torch_xla[tpu])\n",
-            "  Downloading tpu_info-0.3.0-py3-none-any.whl.metadata (3.7 kB)\n",
-            "Requirement already satisfied: grpcio>=1.65.5 in /usr/local/lib/python3.11/dist-packages (from tpu-info->torch_xla[tpu]) (1.73.0)\n",
-            "Requirement already satisfied: protobuf in /usr/local/lib/python3.11/dist-packages (from tpu-info->torch_xla[tpu]) (5.29.5)\n",
-            "Requirement already satisfied: rich in /usr/local/lib/python3.11/dist-packages (from tpu-info->torch_xla[tpu]) (13.9.4)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests->torch_xla[tpu]) (3.4.2)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests->torch_xla[tpu]) (3.10)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests->torch_xla[tpu]) (2.4.0)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests->torch_xla[tpu]) (2025.6.15)\n",
-            "Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.11/dist-packages (from rich->tpu-info->torch_xla[tpu]) (3.0.0)\n",
-            "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.11/dist-packages (from rich->tpu-info->torch_xla[tpu]) (2.19.1)\n",
-            "Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.11/dist-packages (from markdown-it-py>=2.2.0->rich->tpu-info->torch_xla[tpu]) (0.1.2)\n",
-            "Downloading libtpu-0.0.11.1-py3-none-manylinux_2_31_x86_64.whl (130.4 MB)\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m130.4/130.4 MB\u001b[0m \u001b[31m7.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hDownloading tpu_info-0.3.0-py3-none-any.whl (15 kB)\n",
-            "Downloading torch_xla-2.7.0-cp311-cp311-manylinux_2_28_x86_64.whl (96.6 MB)\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m96.6/96.6 MB\u001b[0m \u001b[31m11.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hInstalling collected packages: torch_xla, tpu-info, libtpu\n",
-            "Successfully installed libtpu-0.0.11.1 torch_xla-2.7.0 tpu-info-0.3.0\n"
-          ]
-        }
+      "outputs": [],
+      "source": [
+        "#!pip install torch_xla[tpu]"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "#import torch_xla"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -500,31 +457,9 @@
         "id": "GtiRNfT34-6a",
         "outputId": "c9533c3a-f67e-4fcd-fce4-a4af6e412ce4"
       },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "ImportError",
-          "evalue": "/usr/local/lib/python3.11/dist-packages/_XLAC.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZN5torch4lazy13MetricFnValueB5cxx11Ed",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-            "\u001b[0;32m/tmp/ipython-input-14-846170711.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mtorch_xla\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;32m/usr/local/lib/python3.11/dist-packages/torch_xla/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     18\u001b[0m   \u001b[0msys\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msetdlopenflags\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mflags\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0m_XLAC\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     21\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0m_internal\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtpu\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mversion\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0m__version__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mImportError\u001b[0m: /usr/local/lib/python3.11/dist-packages/_XLAC.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZN5torch4lazy13MetricFnValueB5cxx11Ed",
-            "",
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0;32m\nNOTE: If your import is failing due to a missing package, you can\nmanually install dependencies using either !pip or !apt.\n\nTo view examples of installing some common dependencies, click the\n\"Open Examples\" button below.\n\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n"
-          ],
-          "errorDetails": {
-            "actions": [
-              {
-                "action": "open_url",
-                "actionText": "Open Examples",
-                "url": "/notebooks/snippets/importing_libraries.ipynb"
-              }
-            ]
-          }
-        }
+      "outputs": [],
+      "source": [
+        "#import torch_xla"
       ]
     },
     {
@@ -538,6 +473,7 @@
         "import torch\n",
         "import numpy as np\n",
         "from sklearn.metrics import roc_auc_score\n",
+        "from pathlib import Path\n",
         "import copy\n",
         "\n",
         "\"\"\"Training and Evaluation with Early Stopping\"\"\"\n",
@@ -633,7 +569,10 @@
         "            best_roc_auc = val_roc_auc\n",
         "            epochs_no_improve = 0\n",
         "            best_model_wts = copy.deepcopy(model.state_dict())\n",
-        "            torch.save(model.state_dict(), '/content/drive/MyDrive/Model_III_dataset/lens_classifier_model_vision_transformer.pth')\n",
+        "            torch.save(                #Using config-driven model output path instead of hard-coded filename\n",
+        "                model.state_dict(),\n",
+        "                models_dir / cfg[\"outputs\"][\"model_name\"]\n",
+        "            )\n",
         "            print(f\"New best model saved with Val ROC AUC: {best_roc_auc:.4f}\")\n",
         "        else:\n",
         "            epochs_no_improve += 1\n",
@@ -651,1110 +590,33 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "#torch.save(model.state_dict(), '/content/drive/MyDrive/Model_III_dataset/model_weights.pth')"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "9QBIRCLEkikD",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 141
         },
+        "id": "9QBIRCLEkikD",
         "outputId": "91f23758-e1e5-4da6-da2c-c68f6ff45595"
       },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "NameError",
-          "evalue": "name 'model' is not defined",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-            "\u001b[0;32m/tmp/ipython-input-9-2106813171.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mtorch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstate_dict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'/content/drive/MyDrive/Model_III_dataset/model_weights.pth'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;31mNameError\u001b[0m: name 'model' is not defined"
-          ]
-        }
+      "outputs": [],
+      "source": [
+        "#torch.save(model.state_dict(), '/content/drive/MyDrive/Model_III_dataset/model_weights.pth')"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "-ZJepKUw_txF",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "-ZJepKUw_txF",
         "outputId": "fb8cea1e-a600-45a2-f604-6052f8bbff56"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Optimizer: Adam\n",
-            "Learning Rate: 0.0005\n",
-            "Training on device: cuda\n",
-            "\n",
-            "===== Epoch 1/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n",
-            "/usr/local/lib/python3.11/dist-packages/torch/optim/lr_scheduler.py:243: UserWarning: The epoch parameter in `scheduler.step()` was not necessary and is being deprecated where possible. Please use `scheduler.step()` to step the scheduler. During the deprecation, if epoch is different from None, the closed form is used instead of the new chainable form, where available. Please open an issue if you are unable to replicate your use case: https://github.com/pytorch/pytorch/issues/new/choose.\n",
-            "  warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning)\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 1/200:\n",
-            "Train Loss: 0.9092, Train Accuracy: 0.4850\n",
-            "Val Loss: 0.5946, Val Accuracy: 0.6748, Val ROC AUC: 0.8394\n",
-            "✅ New best model saved with Val ROC AUC: 0.8394\n",
-            "\n",
-            "===== Epoch 2/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 2/200:\n",
-            "Train Loss: 0.6260, Train Accuracy: 0.6503\n",
-            "Val Loss: 0.5740, Val Accuracy: 0.6807, Val ROC AUC: 0.8549\n",
-            "✅ New best model saved with Val ROC AUC: 0.8549\n",
-            "\n",
-            "===== Epoch 3/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 3/200:\n",
-            "Train Loss: 0.5810, Train Accuracy: 0.6884\n",
-            "Val Loss: 0.5053, Val Accuracy: 0.7443, Val ROC AUC: 0.8966\n",
-            "✅ New best model saved with Val ROC AUC: 0.8966\n",
-            "\n",
-            "===== Epoch 4/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 4/200:\n",
-            "Train Loss: 0.5559, Train Accuracy: 0.7091\n",
-            "Val Loss: 0.6880, Val Accuracy: 0.6322, Val ROC AUC: 0.8330\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.8966.\n",
-            "\n",
-            "===== Epoch 5/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 5/200:\n",
-            "Train Loss: 0.5240, Train Accuracy: 0.7328\n",
-            "Val Loss: 0.4144, Val Accuracy: 0.8163, Val ROC AUC: 0.9383\n",
-            "✅ New best model saved with Val ROC AUC: 0.9383\n",
-            "\n",
-            "===== Epoch 6/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 6/200:\n",
-            "Train Loss: 0.4963, Train Accuracy: 0.7604\n",
-            "Val Loss: 0.4904, Val Accuracy: 0.7703, Val ROC AUC: 0.9138\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9383.\n",
-            "\n",
-            "===== Epoch 7/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 7/200:\n",
-            "Train Loss: 0.4268, Train Accuracy: 0.8049\n",
-            "Val Loss: 0.2687, Val Accuracy: 0.8956, Val ROC AUC: 0.9759\n",
-            "✅ New best model saved with Val ROC AUC: 0.9759\n",
-            "\n",
-            "===== Epoch 8/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 8/200:\n",
-            "Train Loss: 0.3901, Train Accuracy: 0.8346\n",
-            "Val Loss: 0.4528, Val Accuracy: 0.8038, Val ROC AUC: 0.9345\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9759.\n",
-            "\n",
-            "===== Epoch 9/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 9/200:\n",
-            "Train Loss: 0.3253, Train Accuracy: 0.8665\n",
-            "Val Loss: 0.1956, Val Accuracy: 0.9268, Val ROC AUC: 0.9869\n",
-            "✅ New best model saved with Val ROC AUC: 0.9869\n",
-            "\n",
-            "===== Epoch 10/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 10/200:\n",
-            "Train Loss: 0.3056, Train Accuracy: 0.8774\n",
-            "Val Loss: 0.2845, Val Accuracy: 0.8890, Val ROC AUC: 0.9734\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9869.\n",
-            "\n",
-            "===== Epoch 11/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 11/200:\n",
-            "Train Loss: 0.2788, Train Accuracy: 0.8919\n",
-            "Val Loss: 0.1745, Val Accuracy: 0.9365, Val ROC AUC: 0.9903\n",
-            "✅ New best model saved with Val ROC AUC: 0.9903\n",
-            "\n",
-            "===== Epoch 12/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 12/200:\n",
-            "Train Loss: 0.2640, Train Accuracy: 0.8992\n",
-            "Val Loss: 0.2380, Val Accuracy: 0.9133, Val ROC AUC: 0.9815\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9903.\n",
-            "\n",
-            "===== Epoch 13/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 13/200:\n",
-            "Train Loss: 0.2433, Train Accuracy: 0.9092\n",
-            "Val Loss: 0.2031, Val Accuracy: 0.9222, Val ROC AUC: 0.9870\n",
-            "⚠️ No improvement in Val ROC AUC for 2 epoch(s). Best is 0.9903.\n",
-            "\n",
-            "===== Epoch 14/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 14/200:\n",
-            "Train Loss: 0.2478, Train Accuracy: 0.9080\n",
-            "Val Loss: 0.2844, Val Accuracy: 0.8917, Val ROC AUC: 0.9789\n",
-            "⚠️ No improvement in Val ROC AUC for 3 epoch(s). Best is 0.9903.\n",
-            "\n",
-            "===== Epoch 15/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 15/200:\n",
-            "Train Loss: 0.2366, Train Accuracy: 0.9119\n",
-            "Val Loss: 0.1688, Val Accuracy: 0.9385, Val ROC AUC: 0.9920\n",
-            "✅ New best model saved with Val ROC AUC: 0.9920\n",
-            "\n",
-            "===== Epoch 16/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 16/200:\n",
-            "Train Loss: 0.2261, Train Accuracy: 0.9153\n",
-            "Val Loss: 0.2232, Val Accuracy: 0.9133, Val ROC AUC: 0.9848\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9920.\n",
-            "\n",
-            "===== Epoch 17/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 17/200:\n",
-            "Train Loss: 0.2157, Train Accuracy: 0.9201\n",
-            "Val Loss: 0.1766, Val Accuracy: 0.9362, Val ROC AUC: 0.9914\n",
-            "⚠️ No improvement in Val ROC AUC for 2 epoch(s). Best is 0.9920.\n",
-            "\n",
-            "===== Epoch 18/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 18/200:\n",
-            "Train Loss: 0.2305, Train Accuracy: 0.9158\n",
-            "Val Loss: 0.2010, Val Accuracy: 0.9263, Val ROC AUC: 0.9835\n",
-            "⚠️ No improvement in Val ROC AUC for 3 epoch(s). Best is 0.9920.\n",
-            "\n",
-            "===== Epoch 19/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 19/200:\n",
-            "Train Loss: 0.2231, Train Accuracy: 0.9194\n",
-            "Val Loss: 0.1821, Val Accuracy: 0.9344, Val ROC AUC: 0.9900\n",
-            "⚠️ No improvement in Val ROC AUC for 4 epoch(s). Best is 0.9920.\n",
-            "\n",
-            "===== Epoch 20/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 20/200:\n",
-            "Train Loss: 0.2101, Train Accuracy: 0.9231\n",
-            "Val Loss: 0.1596, Val Accuracy: 0.9476, Val ROC AUC: 0.9910\n",
-            "⚠️ No improvement in Val ROC AUC for 5 epoch(s). Best is 0.9920.\n",
-            "\n",
-            "===== Epoch 21/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 21/200:\n",
-            "Train Loss: 0.1990, Train Accuracy: 0.9277\n",
-            "Val Loss: 0.1646, Val Accuracy: 0.9391, Val ROC AUC: 0.9903\n",
-            "⚠️ No improvement in Val ROC AUC for 6 epoch(s). Best is 0.9920.\n",
-            "\n",
-            "===== Epoch 22/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 22/200:\n",
-            "Train Loss: 0.2009, Train Accuracy: 0.9268\n",
-            "Val Loss: 0.1438, Val Accuracy: 0.9483, Val ROC AUC: 0.9924\n",
-            "✅ New best model saved with Val ROC AUC: 0.9924\n",
-            "\n",
-            "===== Epoch 23/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 23/200:\n",
-            "Train Loss: 0.2010, Train Accuracy: 0.9278\n",
-            "Val Loss: 0.2015, Val Accuracy: 0.9256, Val ROC AUC: 0.9855\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9924.\n",
-            "\n",
-            "===== Epoch 24/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 24/200:\n",
-            "Train Loss: 0.2141, Train Accuracy: 0.9235\n",
-            "Val Loss: 0.1369, Val Accuracy: 0.9529, Val ROC AUC: 0.9928\n",
-            "✅ New best model saved with Val ROC AUC: 0.9928\n",
-            "\n",
-            "===== Epoch 25/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 25/200:\n",
-            "Train Loss: 0.2007, Train Accuracy: 0.9269\n",
-            "Val Loss: 0.2793, Val Accuracy: 0.9020, Val ROC AUC: 0.9764\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9928.\n",
-            "\n",
-            "===== Epoch 26/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 26/200:\n",
-            "Train Loss: 0.1993, Train Accuracy: 0.9272\n",
-            "Val Loss: 0.1412, Val Accuracy: 0.9520, Val ROC AUC: 0.9917\n",
-            "⚠️ No improvement in Val ROC AUC for 2 epoch(s). Best is 0.9928.\n",
-            "\n",
-            "===== Epoch 27/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 27/200:\n",
-            "Train Loss: 0.1817, Train Accuracy: 0.9351\n",
-            "Val Loss: 0.2009, Val Accuracy: 0.9252, Val ROC AUC: 0.9843\n",
-            "⚠️ No improvement in Val ROC AUC for 3 epoch(s). Best is 0.9928.\n",
-            "\n",
-            "===== Epoch 28/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 28/200:\n",
-            "Train Loss: 0.2001, Train Accuracy: 0.9271\n",
-            "Val Loss: 0.1242, Val Accuracy: 0.9588, Val ROC AUC: 0.9942\n",
-            "✅ New best model saved with Val ROC AUC: 0.9942\n",
-            "\n",
-            "===== Epoch 29/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 29/200:\n",
-            "Train Loss: 0.1764, Train Accuracy: 0.9373\n",
-            "Val Loss: 0.2235, Val Accuracy: 0.9174, Val ROC AUC: 0.9841\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9942.\n",
-            "\n",
-            "===== Epoch 30/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 30/200:\n",
-            "Train Loss: 0.1734, Train Accuracy: 0.9385\n",
-            "Val Loss: 0.1251, Val Accuracy: 0.9576, Val ROC AUC: 0.9935\n",
-            "⚠️ No improvement in Val ROC AUC for 2 epoch(s). Best is 0.9942.\n",
-            "\n",
-            "===== Epoch 31/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 31/200:\n",
-            "Train Loss: 0.1946, Train Accuracy: 0.9306\n",
-            "Val Loss: 0.2429, Val Accuracy: 0.8971, Val ROC AUC: 0.9795\n",
-            "⚠️ No improvement in Val ROC AUC for 3 epoch(s). Best is 0.9942.\n",
-            "\n",
-            "===== Epoch 32/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 32/200:\n",
-            "Train Loss: 0.2203, Train Accuracy: 0.9198\n",
-            "Val Loss: 0.1360, Val Accuracy: 0.9487, Val ROC AUC: 0.9928\n",
-            "⚠️ No improvement in Val ROC AUC for 4 epoch(s). Best is 0.9942.\n",
-            "\n",
-            "===== Epoch 33/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 33/200:\n",
-            "Train Loss: 0.1714, Train Accuracy: 0.9401\n",
-            "Val Loss: 0.2352, Val Accuracy: 0.9176, Val ROC AUC: 0.9870\n",
-            "⚠️ No improvement in Val ROC AUC for 5 epoch(s). Best is 0.9942.\n",
-            "\n",
-            "===== Epoch 34/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 34/200:\n",
-            "Train Loss: 0.1754, Train Accuracy: 0.9386\n",
-            "Val Loss: 0.1072, Val Accuracy: 0.9616, Val ROC AUC: 0.9961\n",
-            "✅ New best model saved with Val ROC AUC: 0.9961\n",
-            "\n",
-            "===== Epoch 35/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 35/200:\n",
-            "Train Loss: 0.1649, Train Accuracy: 0.9426\n",
-            "Val Loss: 0.2433, Val Accuracy: 0.9060, Val ROC AUC: 0.9815\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9961.\n",
-            "\n",
-            "===== Epoch 36/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 36/200:\n",
-            "Train Loss: 0.1713, Train Accuracy: 0.9398\n",
-            "Val Loss: 0.1205, Val Accuracy: 0.9581, Val ROC AUC: 0.9943\n",
-            "⚠️ No improvement in Val ROC AUC for 2 epoch(s). Best is 0.9961.\n",
-            "\n",
-            "===== Epoch 37/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 37/200:\n",
-            "Train Loss: 0.1671, Train Accuracy: 0.9412\n",
-            "Val Loss: 0.2016, Val Accuracy: 0.9250, Val ROC AUC: 0.9878\n",
-            "⚠️ No improvement in Val ROC AUC for 3 epoch(s). Best is 0.9961.\n",
-            "\n",
-            "===== Epoch 38/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 38/200:\n",
-            "Train Loss: 0.1550, Train Accuracy: 0.9458\n",
-            "Val Loss: 0.1049, Val Accuracy: 0.9635, Val ROC AUC: 0.9955\n",
-            "⚠️ No improvement in Val ROC AUC for 4 epoch(s). Best is 0.9961.\n",
-            "\n",
-            "===== Epoch 39/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 39/200:\n",
-            "Train Loss: 0.1474, Train Accuracy: 0.9490\n",
-            "Val Loss: 0.2036, Val Accuracy: 0.9350, Val ROC AUC: 0.9849\n",
-            "⚠️ No improvement in Val ROC AUC for 5 epoch(s). Best is 0.9961.\n",
-            "\n",
-            "===== Epoch 40/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 40/200:\n",
-            "Train Loss: 0.1433, Train Accuracy: 0.9510\n",
-            "Val Loss: 0.0847, Val Accuracy: 0.9712, Val ROC AUC: 0.9970\n",
-            "✅ New best model saved with Val ROC AUC: 0.9970\n",
-            "\n",
-            "===== Epoch 41/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 41/200:\n",
-            "Train Loss: 0.1556, Train Accuracy: 0.9459\n",
-            "Val Loss: 0.1377, Val Accuracy: 0.9508, Val ROC AUC: 0.9931\n",
-            "⚠️ No improvement in Val ROC AUC for 1 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 42/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 42/200:\n",
-            "Train Loss: 0.1400, Train Accuracy: 0.9517\n",
-            "Val Loss: 0.1029, Val Accuracy: 0.9661, Val ROC AUC: 0.9950\n",
-            "⚠️ No improvement in Val ROC AUC for 2 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 43/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 43/200:\n",
-            "Train Loss: 0.1454, Train Accuracy: 0.9503\n",
-            "Val Loss: 0.2245, Val Accuracy: 0.9220, Val ROC AUC: 0.9888\n",
-            "⚠️ No improvement in Val ROC AUC for 3 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 44/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 44/200:\n",
-            "Train Loss: 0.1394, Train Accuracy: 0.9523\n",
-            "Val Loss: 0.0874, Val Accuracy: 0.9701, Val ROC AUC: 0.9968\n",
-            "⚠️ No improvement in Val ROC AUC for 4 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 45/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 45/200:\n",
-            "Train Loss: 0.1534, Train Accuracy: 0.9478\n",
-            "Val Loss: 0.1396, Val Accuracy: 0.9518, Val ROC AUC: 0.9925\n",
-            "⚠️ No improvement in Val ROC AUC for 5 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 46/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 46/200:\n",
-            "Train Loss: 0.1505, Train Accuracy: 0.9481\n",
-            "Val Loss: 0.1128, Val Accuracy: 0.9617, Val ROC AUC: 0.9945\n",
-            "⚠️ No improvement in Val ROC AUC for 6 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 47/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 47/200:\n",
-            "Train Loss: 0.1494, Train Accuracy: 0.9485\n",
-            "Val Loss: 0.1788, Val Accuracy: 0.9294, Val ROC AUC: 0.9901\n",
-            "⚠️ No improvement in Val ROC AUC for 7 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 48/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 48/200:\n",
-            "Train Loss: 0.1399, Train Accuracy: 0.9521\n",
-            "Val Loss: 0.1041, Val Accuracy: 0.9647, Val ROC AUC: 0.9956\n",
-            "⚠️ No improvement in Val ROC AUC for 8 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 49/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 49/200:\n",
-            "Train Loss: 0.1363, Train Accuracy: 0.9537\n",
-            "Val Loss: 0.1726, Val Accuracy: 0.9388, Val ROC AUC: 0.9912\n",
-            "⚠️ No improvement in Val ROC AUC for 9 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "===== Epoch 50/200 =====\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.11/dist-packages/torch/utils/data/dataloader.py:624: UserWarning: This DataLoader will create 4 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "[SUMMARY] Epoch 50/200:\n",
-            "Train Loss: 0.1385, Train Accuracy: 0.9533\n",
-            "Val Loss: 0.0885, Val Accuracy: 0.9710, Val ROC AUC: 0.9965\n",
-            "⚠️ No improvement in Val ROC AUC for 10 epoch(s). Best is 0.9970.\n",
-            "\n",
-            "🛑 Early stopping triggered after 10 epochs without improvement.\n",
-            "\n",
-            "Training Complete!\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
+        "import torch.optim as optim\n",
         "\"\"\"\n",
         "Args:\n",
         "        image_size (int): Size of the input image (e.g., 224).\n",
@@ -1797,33 +659,20 @@
         "print(f\"Learning Rate: {learning_rate}\")\n",
         "\n",
         "# Train Model\n",
-        "model, all_probs, all_labels = train_model(model, train_loader, val_loader, criterion, optimizer, scheduler, num_epochs)"
+        "model, all_probs, all_labels = train_model(model, train_loader, val_loader, criterion, optimizer, scheduler)"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "G_-lEQtu_txF",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "G_-lEQtu_txF",
         "outputId": "380b9897-dd4d-40ef-ba22-02663ddea4b9"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Generating ROC Curve\n",
-            "Class 0 ROC AUC: 0.9985\n",
-            "Class 1 ROC AUC: 0.9936\n",
-            "Class 2 ROC AUC: 0.9974\n",
-            "ROC Curve saved as roc_curve.png\n",
-            "Training and Evaluation Complete!\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "\"\"\" ROC Curve Plotting Function\"\"\"\n",
         "def plot_roc_curve(all_preds, all_labels):\n",
@@ -1860,7 +709,7 @@
         "    plt.ylabel('True Positive Rate')\n",
         "    plt.title('Receiver Operating Characteristic (ROC) Curve')\n",
         "    plt.legend(loc=\"lower right\")\n",
-        "    plt.savefig('/content/drive/MyDrive/Model_III_dataset/roc_curve.png')\n",
+        "    plt.savefig(figures_dir / \"roc_curve.png\")\n",
         "    plt.close()\n",
         "\n",
         "    print(\"ROC Curve saved as roc_curve.png\")\n",
@@ -1882,12 +731,14 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
     "colab": {
-      "provenance": [],
-      "gpuType": "T4"
+      "gpuType": "T4",
+      "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "lensid-env",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
@@ -1900,9 +751,8 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.2"
-    },
-    "accelerator": "GPU"
+      "version": "3.11.9"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
This PR replaces hard-coded dataset and output paths in vision_transformers_basic.ipynb with configuration-driven values from configs/lensid.yaml.

No training logic or model behavior is changed.

Note: Dataset artifacts (e.g., Model_III.tgz and preprocessed loaders) are not included in the repository.
 training requires users to provide them locally.