### PR TITLE
feat: implement cosine decay learning rate scheduler with warmup.

### DIFF
--- a/utils/schedulers.py
+++ b/utils/schedulers.py
@@ -1,0 +1,18 @@
+import torch.optim as optim
+import math
+
+def get_cosine_schedule_with_warmup(optimizer, num_warmup_steps, num_training_steps):
+    """
+    Creates a Cosine Learning Rate Schedule with a warmup phase.
+    Crucial for training large Vision Transformers on lensing data.
+    """
+    def lr_lambda(current_step):
+        if current_step < num_warmup_steps:
+            return float(current_step) / float(max(1, num_warmup_steps))
+        progress = float(current_step - num_warmup_steps) / float(max(1, num_training_steps - num_warmup_steps))
+        return 0.5 * (1.0 + math.cos(math.pi * progress))
+
+    return optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+if __name__ == "__main__":
+    print("DeepLense Scheduler Utility Initialized.")


### PR DESCRIPTION
Hi mentors! I'm preparing for GSoC 2026. I've added a standardized Cosine Learning Rate Scheduler with a warmup phase to the utils directory. This follows best practices for training Vision Transformers (ViTs) on lensing data, ensuring gradient stability and smoother convergence in early epochs.