### PR TITLE
Fix: syntax errors and broken file classification logic

### DIFF
--- a/DeepLense_Data_Processing_Pipeline_for_the_LSST/debug_classification.py
+++ b/DeepLense_Data_Processing_Pipeline_for_the_LSST/debug_classification.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Debug script to test file classification logic."""
 
+import fnmatch
 from pathlib import Path
 
 # Test the logic directly
@@ -20,30 +21,38 @@ def debug_classify_file(file_path: Path):
     print(f"\nClassifying: {filename}")
     matched_types = []
     
-    # Check patterns in order of specificity (most specific first)
-    pattern_order = ['calexp', 'src', 'postISRCCD', 'bkgd', 'deepCoadd', 'deepCoadd_src', 'raw']
+    # Check patterns in order of specificity (Most specific -> Least specific)
+    # moved deepCoadd_src BEFORE src to prevent partial matches
+    pattern_order = [
+        'deepCoadd_src', 
+        'deepCoadd', 
+        'calexp', 
+        'src', 
+        'postISRCCD', 
+        'bkgd', 
+        'raw'
+    ]
     
     for dataset_type in pattern_order:
         print(f"  Checking dataset_type: {dataset_type}")
         if dataset_type in DATASET_PATTERNS:
             patterns = DATASET_PATTERNS[dataset_type]
             for pattern in patterns:
-                # Convert glob pattern to simple string matching
-                # Remove * and .fits, just check for the prefix/suffix
-                pattern_lower = pattern.lower().replace('*', '').replace('.fits', '')
-                filename_no_fits = filename.replace('.fits', '')
-                print(f"    Pattern: '{pattern}' → '{pattern_lower}'")
-                print(f"    Check if '{pattern_lower}' in '{filename_no_fits}': {pattern_lower in filename_no_fits}")
-                if pattern_lower in filename_no_fits:
+                # Use fnmatch for proper glob pattern matching (e.g. *.fits)
+                is_match = fnmatch.fnmatch(filename, pattern.lower())
+                
+                print(f"    Pattern: '{pattern}'")
+                print(f"    Match result: {is_match}")
+                
+                if is_match:
                     matched_types.append(dataset_type)
                     print(f"    ✓ MATCH! Adding {dataset_type}")
                     break
-            # Stop at first match to avoid multiple classifications
+        
             if matched_types:
                 print(f"  Found match, stopping: {matched_types}")
                 break
-    
-    # Default to 'raw' if no specific type detected
+
     if not matched_types:
         matched_types = ['raw']
         print(f"  No matches, defaulting to: {matched_types}")
@@ -54,7 +63,8 @@ def debug_classify_file(file_path: Path):
 test_files = [
     "calexp_HSC-r_00123456_10.fits",
     "src_HSC-r_00123456_10.fits", 
-    "raw_HSC-r_00123456_10.fits"
+    "raw_HSC-r_00123456_10.fits",
+    "deepCoadd_src_HSC-r.fits" # Added to test the specific case
 ]
 
 print("DEBUGGING FILE CLASSIFICATION")
@@ -62,5 +72,5 @@ print("=" * 50)
 
 for filename in test_files:
     result = debug_classify_file(Path(filename))
-    print(f"RESULT: {filename} → {result}")
+    print(f"RESULT: {filename} -> {result}")
     print()


### PR DESCRIPTION
## Description
This PR fixes critical issues in the file classification debug script: syntax errors caused by some characters and logic errors in the pattern matching algorithm that led to misclassification of data products.

## Changes


###  Logic Improvements
- **Implemented `fnmatch`:** Replaced the manual string hacking logic (removing `*` and checking for substrings) with Python's built-in `fnmatch` library.
  - *Issue:* Previously, removing `*` and `.fits` from `*.fits` resulted in an empty string, causing the logic to return `True` for every file.
  - *Fix:* Glob patterns are now strictly respected.
- **Corrected Specificity Order:** Reordered the `pattern_order` list to ensure more specific patterns are checked first.
  - *Issue:* `src` was previously checked before `deepCoadd_src`. Because `deepCoadd_src` contains the substring `src`, these files were being misclassified.
  - *Fix:* `deepCoadd_src` is now checked before generic `src` patterns.

## Testing
- Verified that `deepCoadd_src` files are no longer misclassified as `src`.
- Verified that `raw` files are correctly identified via the fallback logic.