### PR TITLE
Scope Linux-only dependencies to Linux platforms

### DIFF
--- a/DeepLense_Physics_Informed_Super_Resolution_Anirudh_Shankar/simulations.txt
+++ b/DeepLense_Physics_Informed_Super_Resolution_Anirudh_Shankar/simulations.txt
@@ -1,7 +1,7 @@
 apturl==0.5.2
 bcrypt==3.2.0
 blinker==1.4
-Brlapi==0.8.3
+Brlapi==0.8.3; platform_system == "Linux"
 certifi==2020.6.20
 chardet==4.0.0
 click==8.0.3
@@ -62,7 +62,7 @@ scipy==1.14.1
 screen-resolution-extra==0.0.0
 SecretStorage==3.3.1
 six==1.16.0
-systemd-python==234
+systemd-python==234; platform_system == "Linux"
 ubuntu-advantage-tools==8001
 ubuntu-drivers-common==0.0.0
 ufw==0.36.1

--- a/Grid_based_strong_lensing_for_unsupervised_super_resolution_Anirudh_Shankar/requirements.txt
+++ b/Grid_based_strong_lensing_for_unsupervised_super_resolution_Anirudh_Shankar/requirements.txt
@@ -3,7 +3,7 @@ apturl==0.5.2
 asttokens==3.0.0
 bcrypt==3.2.0
 blinker==1.4
-Brlapi==0.8.3
+Brlapi==0.8.3; platform_system == "Linux"
 CacheControl==0.12.10
 cachy==0.3.0
 certifi==2020.6.20
@@ -109,7 +109,7 @@ pymacaroons==0.13.0
 PyNaCl==1.5.0
 pyparsing==2.4.7
 pyRFC3339==1.1
-python-apt==2.4.0+ubuntu4
+python-apt==2.4.0+ubuntu4; platform_system == "Linux"
 python-dateutil==2.9.0.post0
 python-debian==0.1.43+ubuntu1.1
 pytz==2022.1
@@ -127,7 +127,7 @@ six==1.16.0
 ssh-import-id==5.11
 stack-data==0.6.3
 sympy==1.13.1
-systemd-python==234
+systemd-python==234; platform_system == "Linux"
 tensorboard==2.19.0
 tensorboard-data-server==0.7.2
 tomlkit==0.9.2


### PR DESCRIPTION
This PR fixes cross-platform installation failures on Windows and macOS caused by Linux-only dependencies listed in dependency files.

Although PR #97 removed the apturl blocker, installation still fails on non-Linux systems because the following Ubuntu/Linux-specific packages are included unconditionally:
Brlapi
python-apt
systemd-python
These packages are not available on PyPI for Windows or macOS, which causes pip install to fail.

What changed
Added platform_system == "Linux" markers to Linux-only dependencies in:
requirements.txt
simulations.txt

This ensures:
Dependencies are installed normally on Linux
pip safely skips them on Windows/macOS

How to reproduce
On Windows/macOS:
pip install -r requirements.txt

Before: Installation fails with
No matching distribution found for Brlapi

After: Installation proceeds successfully
Environment
OS: Windows 10
Python: 3.11.9
Fresh virtual environment
Related issue

Fixes #103