### PR TITLE
Docs: explain configuration and dataset flow in DeepLense SSL

### DIFF
--- a/DeepLense_SSL_from_real_dataset_Sreehari_Iyer/ssltrain.py
+++ b/DeepLense_SSL_from_real_dataset_Sreehari_Iyer/ssltrain.py
@@ -89,6 +89,10 @@ class ImageDataset(Dataset):
         return image, self.label[idx]
 
 def main():
+    # ------------------------------------------------------------
+    # 1. Load configuration files and set up experiment environment
+    # ------------------------------------------------------------
+
     # Ensure a config file is provided as a command-line argument
     if len(sys.argv) not in [2,3]:
         print("Usage: python main.py <config_file> <optional_default_config_file>")
@@ -152,8 +156,11 @@ def main():
     #--------------------------------------------------------------------------------------------------------
 
     
-    #--------------------------------------------------------------------------------------------------------
-    # compute mean and std based on the training dataset
+    # ------------------------------------------------------------
+    # 2. Compute dataset statistics (mean & std) from training data
+    #    Used for normalization in SSL augmentations
+    # ------------------------------------------------------------
+
     data_path = args["input"]["data path"]
     indices = None
     with open(args["input"]["indices"], "rb") as f:
@@ -221,7 +228,11 @@ def main():
     #--------------------------------------------------------------------------------------------------------
 
         
-    # initialize ssl training object
+    # ------------------------------------------------------------
+    # 3. Initialize SSL training method (DINO / SimSiam / iBOT)
+    #    This block selects and configures the chosen SSL algorithm
+    # ------------------------------------------------------------
+
     ssl_training = None
     if args["experiment"]["ssl_training"] is None:
         print("`ssl_training` which specifies the training method cannot be `None`. Exiting.")

--- a/DeepLense_SSL_from_real_dataset_Sreehari_Iyer/ssltrain.py
+++ b/DeepLense_SSL_from_real_dataset_Sreehari_Iyer/ssltrain.py
@@ -1,3 +1,31 @@
+"""
+ssltrain.py
+
+High-level training script for self-supervised learning (SSL) on real-world
+gravitational lensing images using Vision Transformers (ViTs).
+
+This script supports multiple SSL methods:
+- DINO
+- iBOT
+- SimSiam
+
+Overall training flow:
+1. Load and merge YAML configuration files
+2. Set random seeds and experiment directories
+3. Initialize Vision Transformer backbone(s)
+   - Student network (always)
+   - Teacher network (for DINO / iBOT)
+4. Load dataset paths using predefined train/val/test indices
+5. Compute dataset mean and standard deviation for normalization
+6. Build SSL-specific data augmentations
+7. Initialize the selected SSL training framework
+8. Run SSL pretraining
+9. Save the learned representation network
+
+This file is intentionally modular so that new SSL methods,
+augmentations, or backbones can be added with minimal changes.
+"""
+
 import os
 import sys
 import logging

--- a/docs/configuration_and_dataset_flow.md
+++ b/docs/configuration_and_dataset_flow.md
@@ -1,0 +1,117 @@
+# Configuration and Dataset Flow in DeepLense SSL
+
+This document explains how configuration files, dataset paths, and indices are used in the DeepLense self-supervised learning (SSL) pipeline.  
+It is intended for new contributors running the code locally for the first time.
+
+---
+
+## 1. Expected Dataset Structure
+
+DeepLense SSL assumes the dataset directory has the following structure:
+
+```text
+data_root/
+├── lenses/
+│   ├── image_001.npy
+│   ├── image_002.npy
+│   └── ...
+└── nonlenses/
+    ├── image_101.npy
+    ├── image_102.npy
+    └── ...
+```
+
+Each image is stored as a NumPy (`.npy`) file.
+- Images typically contain multiple channels (e.g. g, r, i bands).
+- Images are center-cropped to `32 × 32` pixels during training.
+
+The path to `data_root` must be provided in the configuration file under:
+
+```yaml
+input:
+  data path: /path/to/data_root
+```
+---
+## 2. What is `indices.pkl`?
+
+The file `indices.pkl` defines how the dataset is split into training, validation, and test sets.
+
+It contains:
+- Separate indices for **lenses** and **nonlenses**
+- Explicit splits for:
+  - training
+  - validation
+  - testing
+
+This file is required so that:
+- experiments are reproducible
+- all models use the same data splits
+- comparisons between methods remain consistent
+
+The path to this file must be provided in the configuration file under:
+```yaml
+input:
+  indices: /path/to/indices.pkl
+```
+---
+
+## 3. How Configuration Files Are Used
+
+All training behavior in DeepLense SSL is controlled through YAML configuration files, without requiring code changes.
+
+
+At a high level, the execution flow is:
+
+- config.yaml is parsed into an `args` dictionary
+- dataset paths and indices are loaded
+- data augmentations are initialized
+- SSL model (DINO / SimSiam / iBOT) is constructed
+- training loop is executed
+
+
+Key sections in the config include:
+- `experiment`: device, output directory, logging
+- `input`: dataset paths and image parameters
+- `network`: Vision Transformer architecture details
+- `train args`: batch size, epochs, train/validation split
+- `ssl augmentation kwargs`: SSL-specific augmentations
+
+---
+
+## 4. Common Setup Issues
+
+New contributors often encounter the following issues:
+- Incorrect dataset folder structure
+- Missing or mislocated `indices.pkl`
+- GPU-only configs being run on CPU machines
+- Long training runs failing early due to setup errors
+
+Ensuring paths are correct before running long experiments can save significant time.
+
+---
+
+## 5. Quick Sanity Check Configuration
+
+To help verify that the pipeline is set up correctly, a minimal configuration file is provided:
+
+configs/quick-test-simsiam.yaml
+
+
+
+This configuration:
+- Runs on **CPU**
+- Uses **one training epoch**
+- Uses a **small batch size**
+- Is intended only for **sanity checks**, not scientific results
+
+New contributors are encouraged to run this configuration first to confirm that:
+- dataset paths are correct
+- indices load properly
+- the training loop executes end-to-end
+
+---
+
+## 6. When to Use Full Training Configs
+
+Once the quick test configuration runs successfully, users can switch to full training configurations (e.g. DINO or iBOT) for actual experiments and result generation.
+


### PR DESCRIPTION
This PR adds a beginner-friendly documentation page explaining how configuration
files, dataset paths, and indices are used in the DeepLense SSL pipeline.

It covers:
- Expected dataset directory structure
- Purpose and usage of `indices.pkl`
- How YAML configuration files control the training flow
- Common setup issues faced by new contributors
- A recommended quick sanity-check configuration for onboarding

This documentation is intended to reduce setup friction, improve reproducibility,
and help first-time contributors run the SSL pipeline correctly before launching
long experiments.

No training or model logic is modified.
