### PR TITLE
Fix: resolve dimension errors and add RC2 explorer

### DIFF
--- a/DeepLense_Data_Processing_Pipeline_for_the_LSST/test_validator.py
+++ b/DeepLense_Data_Processing_Pipeline_for_the_LSST/test_validator.py
@@ -47,20 +47,25 @@ def test_validator_for_repo(repo_path: str, repo_name: str):
         
         # Test coverage report
         logger.info("\n=== Coverage Report ===")
-        coverage = validator.get_data_coverage(
-            dataset_types=["calexp", "src"],
-            filters=["r"]
-        )
-        
-        logger.info(f"Total data IDs: {coverage.total_data_ids}")
-        logger.info(f"Available: {coverage.available_data_ids}")
-        logger.info(f"Missing: {coverage.missing_data_ids}")
-        logger.info(f"Coverage: {coverage.coverage_percentage:.1f}%")
-        logger.info(f"Instruments: {coverage.instruments}")
-        logger.info(f"Filters: {coverage.filters}")
-        
-        if coverage.failed_data_ids:
-            logger.info(f"Failed data IDs (first 3): {coverage.failed_data_ids[:3]}")
+        try:
+            coverage = validator.get_data_coverage(
+                dataset_types=["calexp", "src"],
+                filters=["r"],
+                instruments=list(result.instruments)  # FIX: Added to prevent governor dimension errors
+            )
+            
+            logger.info(f"Total data IDs: {coverage.total_data_ids}")
+            logger.info(f"Available: {coverage.available_data_ids}")
+            logger.info(f"Missing: {coverage.missing_data_ids}")
+            logger.info(f"Coverage: {coverage.coverage_percentage:.1f}%")
+            logger.info(f"Instruments: {coverage.instruments}")
+            logger.info(f"Filters: {coverage.filters}")
+            
+            if coverage.failed_data_ids:
+                logger.info(f"Failed data IDs (first 3): {coverage.failed_data_ids[:3]}")
+                
+        except Exception as e:
+            logger.error(f"Coverage report generation failed: {e}")
         
     else:
         logger.error(f"✗ Repository validation failed: {result.error_message}")


### PR DESCRIPTION
## Summary
This PR addresses critical issues in the `ButlerRepoValidator` usage where coverage reporting failed due to missing governor dimensions (instruments). It also introduces new utility scripts for exploring the RC2 subset repository and cleans up syntax errors caused by non-breaking spaces in existing scripts.

## Key Changes
- **Fix Coverage Calculation:** Updated `get_data_coverage` calls in test scripts to explicitly pass `instruments=list(result.instruments)`. This resolves the "governor dimension" error when querying the Butler registry.
- **New Exploration Script:** Added `explore_rc2_repository.py` to provide deep introspection into the RC2 subset, including detailed collection analysis and dataset type discovery.
- **Syntax Cleanup:** Removed invisible non-breaking space characters (`\xa0`) from all test scripts that were causing Python `SyntaxError`s.
- **API Safety:** Updated Butler query calls to use list containers for single objects (e.g., `datasets=[dataset_type_obj]`) to ensure strict API compatibility.

## Testing
- [x] Verified `explore_rc2_repository.py` runs successfully against the `rc2_subset/SMALL_HSC` path.
- [x] Verified `test_fixed_coverage_report.py` runs against `demo_data` without throwing dimension errors.
- [x] Confirmed that `ButlerRepoValidator` correctly identifies `calexp` and `src` datasets in the new RC2 environment.

## Context
Previously, the `get_data_coverage` method would fail on repositories requiring strict dimension governance because the `instrument` dimension was not being propagated to the query. This PR ensures the discovered instruments are passed back to the coverage calculator.