### PR TITLE
Fix: Prevent NaN errors and optimize tensor loading in LensingDataset

### DIFF
--- a/Grid_based_strong_lensing_for_unsupervised_super_resolution_Anirudh_Shankar/data.py
+++ b/Grid_based_strong_lensing_for_unsupervised_super_resolution_Anirudh_Shankar/data.py
@@ -1,6 +1,7 @@
+import os
 import torch
 import numpy as np
-    
+
 class LensingDataset(torch.utils.data.Dataset):
     def __init__(self, directory, classes, num_samples):
         """
@@ -14,11 +15,12 @@ class LensingDataset(torch.utils.data.Dataset):
         self.directory = directory
         self.classes = classes
         self.num_samples = num_samples
+
     def __len__(self):
         """
         :return: Returns the length of the dataset
         """
-        return self.num_samples*len(self.classes)
+        return self.num_samples * len(self.classes)
     
     def __getitem__(self, index):
         """
@@ -27,8 +29,20 @@ class LensingDataset(torch.utils.data.Dataset):
         :param index: Index in the dataset to look for
         :return: LR image, min-max normalized
         """
-        selected_class = self.classes[index//self.num_samples]
-        class_index = index%self.num_samples
-        image = torch.tensor(np.array([np.load(self.directory+selected_class+'/sim_%d.npy'%(class_index))]))
-        image = (image - torch.min(image))/(torch.max(image)-torch.min(image))
+        # Determine class and specific image index
+        selected_class = self.classes[index // self.num_samples]
+        class_index = index % self.num_samples
+        
+        # Safely construct the file path using f-strings and os.path.join
+        file_path = os.path.join(self.directory, selected_class, f'sim_{class_index}.npy')
+        
+        # Load efficiently and add the channel dimension (1, H, W)
+        np_img = np.load(file_path)
+        image = torch.from_numpy(np_img).float().unsqueeze(0)
+        
+        # Safe min-max normalization (adding 1e-8 prevents division by zero)
+        img_min = torch.min(image)
+        img_max = torch.max(image)
+        image = (image - img_min) / (img_max - img_min + 1e-8)
+        
         return image


### PR DESCRIPTION

This PR addresses a critical mathematical bug in the `LensingDataset` normalization logic and optimizes how image arrays are loaded into PyTorch tensors. It also fixes fragile file path handling to prevent `FileNotFoundError`s across different operating systems.

## Changes Made
* **Zero-Division Prevention:** Added a small epsilon (`1e-8`) to the denominator during min-max normalization. This prevents the tensor from filling with `NaN`s if an image happens to have uniform pixel values (where `max == min`).
* **Safe Path Handling:** Replaced the hardcoded string concatenation (`self.directory + selected_class + '/sim_%d.npy'`) with `os.path.join()` for safe, cross-platform path resolution.
* **Tensor Optimization:** Swapped `torch.tensor(np.array([np.load(...)])` for `torch.from_numpy(np.load(...)).unsqueeze(0)`. This avoids allocating an intermediate NumPy array and shares memory directly, speeding up the `__getitem__` pipeline.
* **String Formatting:** Modernized file path string formatting from `%d` to f-strings.
* **Whitespace Cleanup:** Removed hidden non-breaking spaces that could cause Python syntax errors.

## Context
During training, a single blank or uniformly colored image in the dataset would cause the min-max normalizer to divide by zero, instantly ruining model gradients with `NaN` values. Furthermore, the dataset loader was previously creating unnecessary memory copies of every image, which creates a bottleneck during data loading. This refactor makes the dataloader safer, faster, and more robust.
